### PR TITLE
Corrected problems 8.5.2 and 8.5.9

### DIFF
--- a/Chapter 08 - Estimating the CDF and Statistical Functionals.ipynb
+++ b/Chapter 08 - Estimating the CDF and Statistical Functionals.ipynb
@@ -266,11 +266,11 @@
     "\n",
     "$p$ is the mean of $\\text{Bernoulli}(p)$, so its plugin estimator is $\\hat{p} = \\mathbb{E}(\\hat{F_n}) = n^{-1} \\sum_{i=1}^n X_i  = \\overline{X}_n$.\n",
     "\n",
-    "$\\sqrt{p(1-p)}$ is the standard error of $\\text{Bernoulli}(p)$, so its plugin estimator is $\\sqrt{\\hat{p}(1-\\hat{p})} = \\sqrt{\\overline{X}_n(1 - \\overline{X}_n)}$.\n",
+    "$\\sqrt{p(1-p)}$ is the standard deviation of $\\text{Bernoulli}(p)$, so the plugin estimator for the standard error is $\\sqrt{\\frac{\\hat{p}(1-\\hat{p})}{n}} = \\sqrt{\\frac{\\overline{X}_n(1 - \\overline{X}_n)}{n}}$.\n",
     "\n",
     "**(b)**\n",
     "\n",
-    "The 90-percent confidence interval for $p$ is $\\hat{p} \\pm z_{5\\%} \\hat{se}(\\hat{p})= \\overline{X}_n \\pm z_{5\\%} \\sqrt{\\overline{X}_n(1-\\overline{X}_n)}$.\n",
+    "The 90-percent confidence interval for $p$ is $\\hat{p} \\pm z_{5\\%} \\hat{se}(\\hat{p})= \\overline{X}_n \\pm z_{5\\%} \\sqrt{\\frac{\\overline{X}_n(1-\\overline{X}_n)}{n}}$.\n",
     "\n",
     "**(c)**\n",
     "\n",
@@ -278,11 +278,11 @@
     "\n",
     "The standard error of $\\hat{\\theta}$ is\n",
     "\n",
-    "$$\\text{se} = \\sqrt{\\mathbb{V}(\\hat{p} - \\hat{q})} = \\sqrt{\\mathbb{V}(\\hat{p}) + \\mathbb{V}(\\hat{q})} = \\sqrt{\\hat{p}(1 - \\hat{p}) + \\hat{q}(1 - \\hat{q})} = \\sqrt{\\overline{X}_n(1 - \\overline{X}_n) + \\overline{Y}_m(1 - \\overline{Y}_m)} $$\n",
+    "$$\\text{se} = \\sqrt{\\mathbb{V}(\\hat{p} - \\hat{q})} = \\sqrt{\\mathbb{V}(\\hat{p}) + \\mathbb{V}(\\hat{q})} = \\sqrt{\\frac{\\hat{p}(1 - \\hat{p})}{n} + \\frac{\\hat{q}(1 - \\hat{q})}{n}} = \\sqrt{\\frac{\\overline{X}_n(1 - \\overline{X}_n)}{n} + \\frac{\\overline{Y}_m(1 - \\overline{Y}_m)}{n}} $$\n",
     "\n",
     "**(d)**\n",
     "\n",
-    "The 90-percent confidence interval for $\\theta = p - q$ is $\\hat{\\theta} \\pm z_{5\\%} \\hat{se}(\\hat{\\theta}) = \\overline{X}_n - \\overline{Y}_m \\pm z_{5\\%} \\sqrt{\\overline{X}_n(1 - \\overline{X}_n) + \\overline{Y}_m(1 - \\overline{Y}_m)} $"
+    "The 90-percent confidence interval for $\\theta = p - q$ is $\\hat{\\theta} \\pm z_{5\\%} \\hat{se}(\\hat{\\theta}) = \\overline{X}_n - \\overline{Y}_m \\pm z_{5\\%} \\sqrt{\\frac{\\overline{X}_n(1 - \\overline{X}_n)}{n} + \\frac{\\overline{Y}_m(1 - \\overline{Y}_m)}{n}} $"
    ]
   },
   {
@@ -920,18 +920,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Solution**. Let $X_1, \\dots, X_100$ be indicator random variables (0 or 1) determining recovery on the first group, and $Y_1, \\dots, Y_100$ indicating recovery on the second group. From the problem formulation, we can assume $X_i \\sim \\text{Bernoulli}(p_1)$ and $Y_i \\sim \\text{Bernoulli}(p_2)$.\n",
+    "**Solution**. Let $X_1, \\dots, X_100$ be indicator random variables (0 or 1) determining recovery on the first group, and $Y_1, \\dots, Y_100$ indicating recovery on the second group. From the problem formulation, we can assume $X_i \\sim \\text{Bernoulli}(p_1)$ and $Y_i \\sim \\text{Bernoulli}(p_2)$. $n_1 = n_2 = 100$, so we can use $n$ to refer to both.\n",
     "\n",
     "If $\\theta = p_1 - p_2$, then from exercise 8.5.2:\n",
     "\n",
     "$$\\hat{\\theta} = \\hat{p_1} - \\hat{p_2}$$\n",
     "\n",
-    "$$\\text{se}(\\hat{\\theta}) = \\sqrt{\\hat{p_1}(1 - \\hat{p_1}) + \\hat{p_2}(1 - \\hat{p_2})}$$"
+    "$$\\text{se}(\\hat{\\theta}) = \\sqrt{\\frac{\\hat{p_1}(1 - \\hat{p_1})}{n} + \\frac{\\hat{p_2}(1 - \\hat{p_2})}{n}}$$"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -939,7 +939,7 @@
      "output_type": "stream",
      "text": [
       "Estimated mean: 0.050\n",
-      "Estimated SE: 0.466\n"
+      "Estimated SE: 0.047\n"
      ]
     }
    ],
@@ -948,9 +948,10 @@
     "\n",
     "p_hat_1 = 0.9\n",
     "p_hat_2 = 0.85\n",
+    "n = 100\n",
     "\n",
     "theta_hat = p_hat_1 - p_hat_2\n",
-    "se_theta_hat = math.sqrt(p_hat_1 * (1 - p_hat_1) + p_hat_2 * (1 - p_hat_2))\n",
+    "se_theta_hat = math.sqrt((p_hat_1 * (1 - p_hat_1) + p_hat_2 * (1 - p_hat_2)) / n)\n",
     "\n",
     "print('Estimated mean: %.3f' % theta_hat)\n",
     "print('Estimated SE: %.3f'   % se_theta_hat)"
@@ -958,15 +959,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "80% confidence interval: (-0.548, 0.648)\n",
-      "95% confidence interval: (-0.864, 0.964)\n"
+      "80% confidence interval: (-0.010, 0.110)\n",
+      "95% confidence interval: (-0.041, 0.141)\n"
      ]
     }
    ],


### PR DESCRIPTION
The standard error for the estimator of a bernoulli distribution should be sqrt(p * (1 - p) / n) instead of just sqrt(p * (1 - p)), which is the standard deviation of the regular distribution. This was fixed in problems 8.5.2 and 8.5.9